### PR TITLE
remove 'docs' from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,5 @@
 web/node_modules
 web/dist
 legacy
-docs
 *.md
 !README.md


### PR DESCRIPTION
Remove 'docs' from .dockerignore to include documentation files.