### PR TITLE
feat: configurable B50 export modes & song detail player scores

### DIFF
--- a/web/src/api/record.ts
+++ b/web/src/api/record.ts
@@ -14,7 +14,8 @@ export const getRecords = (
   pageIndex: number = 1,
   sortBy: string = 'rating',
   order: string = 'desc',
-  filter?: RecordFilterParams
+  filter?: RecordFilterParams,
+  underflow?: number,
 ) => {
   const params: Record<string, unknown> = {
     scope,
@@ -23,6 +24,7 @@ export const getRecords = (
     sort_by: sortBy,
     order,
   }
+  if (underflow != null) params.underflow = underflow
   if (filter?.minLevel != null) params.min_level = filter.minLevel
   if (filter?.maxLevel != null) params.max_level = filter.maxLevel
   if (filter?.difficulties && filter.difficulties.length > 0) {
@@ -42,4 +44,10 @@ export const uploadRecords = (username: string, data: BatchCreatePlayRecordReque
 
 export const getAllChartsWithScores = (username: string) => {
   return client.get<AllChartsResponse>(`/records/${username}`, { params: { scope: 'all-charts' } })
+}
+
+export const getSongRecords = (username: string, songAddr: string, scope: string = 'best') => {
+  return client.get<PlayRecordResponse>(`/records/${username}/song/${songAddr}`, {
+    params: { scope },
+  })
 }

--- a/web/src/components/business/B50ExportModal.vue
+++ b/web/src/components/business/B50ExportModal.vue
@@ -90,10 +90,8 @@ const handleExport = async () => {
       const b15 = records.filter((r) => r.chart.b15)
       const b35 = records.filter((r) => !r.chart.b15)
       sections = [
-        { label: 'Best 15', avg: avgRating(b15.slice(0, 15)), records: b15.slice(0, 15) },
-        { label: 'Best 35', avg: avgRating(b35.slice(0, 35)), records: b35.slice(0, 35) },
-        { label: 'Overflow (B15)', avg: avgRating(b15.slice(15)), records: b15.slice(15) },
-        { label: 'Overflow (B35)', avg: avgRating(b35.slice(35)), records: b35.slice(35) },
+        { label: 'Best 15', avg: avgRating(b15.slice(0, 15)), records: b15, cutoff: 15 },
+        { label: 'Best 35', avg: avgRating(b35.slice(0, 35)), records: b35, cutoff: 35 },
       ]
     } else {
       if (USE_MOCK) {

--- a/web/src/components/business/B50ExportModal.vue
+++ b/web/src/components/business/B50ExportModal.vue
@@ -1,0 +1,152 @@
+<template>
+  <n-modal
+    :show="show"
+    preset="card"
+    :title="t('common.export_image')"
+    style="width: 420px; max-width: 90vw; max-height: 90vh;"
+    content-style="display: flex; flex-direction: column; overflow: hidden;"
+    :bordered="false"
+    :auto-focus="false"
+    content-scrollable
+    @update:show="$emit('update:show', $event)"
+  >
+    <div class="export-options">
+      <span class="option-label">{{ t('term.export_mode') }}</span>
+      <n-radio-group v-model:value="mode" class="mode-group">
+        <n-radio value="standard">{{ t('term.b50_standard') }}</n-radio>
+        <n-radio value="overflow">{{ t('term.b50_overflow') }}</n-radio>
+        <n-radio value="global">{{ t('term.b50_global') }}</n-radio>
+      </n-radio-group>
+    </div>
+
+    <template #footer>
+      <div class="confirm-actions">
+        <BaseButton variant="secondary" @click="show = false" :text="t('common.cancel')" />
+        <BaseButton
+          :disabled="exporting"
+          @click="handleExport"
+          :text="exporting ? t('common.loading') : t('common.export_image')"
+        />
+      </div>
+    </template>
+  </n-modal>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { NModal, NRadioGroup, NRadio } from 'naive-ui'
+import { saveAs } from 'file-saver'
+import BaseButton from '@/components/ui/BaseButton.vue'
+import { getRecords } from '@/api/record'
+import { USE_MOCK } from '@/api/mock'
+import { renderB50Image, type B50Section } from '@/utils/b50Canvas'
+import type { PlayRecordInfo } from '@/api/types'
+import { toastSuccess, toastError } from '@/utils/toast'
+
+const { t } = useI18n()
+
+const show = defineModel<boolean>('show', { required: true })
+
+const props = defineProps<{
+  username: string
+  nickname: string
+  rating: number
+  b15Records: PlayRecordInfo[]
+  b35Records: PlayRecordInfo[]
+  b15Avg: number
+  b35Avg: number
+}>()
+
+const mode = ref<'standard' | 'overflow' | 'global'>('standard')
+const exporting = ref(false)
+
+function avgRating(records: PlayRecordInfo[]): number {
+  if (records.length === 0) return 0
+  return records.reduce((s, r) => s + r.rating, 0) / (records.length * 100)
+}
+
+const handleExport = async () => {
+  if (exporting.value) return
+  exporting.value = true
+
+  try {
+    let sections: B50Section[]
+    let rating = props.rating
+    let title: string | undefined
+
+    if (mode.value === 'standard') {
+      sections = [
+        { label: 'Best 15', avg: props.b15Avg, records: props.b15Records },
+        { label: 'Best 35', avg: props.b35Avg, records: props.b35Records },
+      ]
+    } else if (mode.value === 'overflow') {
+      if (USE_MOCK) {
+        toastError('message.export_image_failed')
+        return
+      }
+      const res = await getRecords(props.username, 'b50', 50, 1, 'rating', 'desc', undefined, 5)
+      const records = res.data.records
+      const b15 = records.filter((r) => r.chart.b15)
+      const b35 = records.filter((r) => !r.chart.b15)
+      sections = [
+        { label: 'Best 15', avg: avgRating(b15.slice(0, 15)), records: b15.slice(0, 15) },
+        { label: 'Best 35', avg: avgRating(b35.slice(0, 35)), records: b35.slice(0, 35) },
+        { label: 'Overflow (B15)', avg: avgRating(b15.slice(15)), records: b15.slice(15) },
+        { label: 'Overflow (B35)', avg: avgRating(b35.slice(35)), records: b35.slice(35) },
+      ]
+    } else {
+      if (USE_MOCK) {
+        toastError('message.export_image_failed')
+        return
+      }
+      const res = await getRecords(props.username, 'all', 50, 1, 'rating', 'desc')
+      const records = res.data.records
+      sections = [
+        { label: 'Best 50', avg: avgRating(records), records: records.slice(0, 50) },
+      ]
+      rating = avgRating(records.slice(0, 50))
+      title = 'Paradigm: Reboot Global Best Records'
+    }
+
+    const blob = await renderB50Image({
+      sections,
+      username: props.username,
+      nickname: props.nickname,
+      rating,
+      title,
+    })
+    saveAs(blob, `b50_${mode.value}_${Date.now()}.jpg`)
+    toastSuccess('message.export_image_success')
+    show.value = false
+  } catch (err: unknown) {
+    toastError('message.export_image_failed', err)
+  } finally {
+    exporting.value = false
+  }
+}
+</script>
+
+<style scoped>
+.export-options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin: var(--space-2) 0;
+}
+.option-label {
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  font-weight: 500;
+}
+.mode-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+}
+</style>

--- a/web/src/components/business/SongDetailModal.vue
+++ b/web/src/components/business/SongDetailModal.vue
@@ -56,10 +56,13 @@
             <span class="info-label">{{ t('term.difficulty') }}</span>
             <div class="charts-list">
               <div v-for="chart in sortedCharts" :key="chart.id" class="chart-row">
-                <DifficultyBadge :difficulty="chart.difficulty" :level="chart.level" />
-                <span class="chart-designer">{{ chart.level_design }}</span>
-                <span v-if="chart.notes" class="chart-notes mono">{{ chart.notes }} {{ t('term.notes') }}</span>
+                <div class="chart-row-meta">
+                  <DifficultyBadge :difficulty="chart.difficulty" :level="chart.level" />
+                  <span class="chart-designer">{{ chart.level_design }}</span>
+                  <span v-if="chart.notes" class="chart-notes mono">{{ chart.notes }} {{ t('term.notes') }}</span>
+                </div>
                 <div v-if="getRecord(chart.id)" class="chart-record">
+                  <span class="record-label">{{ t('term.best_score') }}</span>
                   <span class="mono">{{ getRecord(chart.id)!.score.toLocaleString() }}</span>
                   <span class="mono record-rating">{{ (getRecord(chart.id)!.rating / 100).toFixed(2) }}</span>
                 </div>
@@ -210,37 +213,55 @@ const coverUrl = computed(() => {
 }
 .chart-row {
   display: flex;
-  align-items: center;
-  gap: var(--space-3);
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--space-2);
   padding: var(--space-2) var(--space-3);
   background: var(--bg-secondary);
   border-radius: 6px;
+}
+.chart-row-meta {
+  display: flex;
+  align-items: center;
   flex-wrap: wrap;
+  gap: var(--space-2) var(--space-3);
 }
 .chart-designer {
   font-size: var(--text-sm);
   color: var(--text-secondary);
-  flex: 1;
+  flex: 1 1 auto;
+  min-width: 0;
+  word-break: break-word;
 }
 .chart-notes {
   font-size: var(--text-xs);
   color: var(--text-muted);
+  flex-shrink: 0;
 }
 .chart-record {
   display: flex;
-  align-items: center;
-  gap: var(--space-3);
+  align-items: baseline;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-3);
   font-size: var(--text-sm);
   color: var(--text-primary);
+}
+.record-label {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  margin-right: auto;
 }
 .record-rating {
   color: var(--accent);
   font-weight: 600;
 }
 @media (max-width: 479px) {
-  .chart-record {
-    width: 100%;
-    justify-content: flex-end;
+  .chart-designer {
+    flex-basis: 100%;
   }
 }
 .loading-state {

--- a/web/src/components/business/SongDetailModal.vue
+++ b/web/src/components/business/SongDetailModal.vue
@@ -59,6 +59,10 @@
                 <DifficultyBadge :difficulty="chart.difficulty" :level="chart.level" />
                 <span class="chart-designer">{{ chart.level_design }}</span>
                 <span v-if="chart.notes" class="chart-notes mono">{{ chart.notes }} {{ t('term.notes') }}</span>
+                <div v-if="getRecord(chart.id)" class="chart-record">
+                  <span class="mono">{{ getRecord(chart.id)!.score.toLocaleString() }}</span>
+                  <span class="mono record-rating">{{ (getRecord(chart.id)!.rating / 100).toFixed(2) }}</span>
+                </div>
               </div>
             </div>
           </div>
@@ -72,13 +76,14 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { NSpin, NModal } from 'naive-ui'
-import type { Song } from '@/api/types'
+import type { Song, PlayRecordInfo } from '@/api/types'
 import DifficultyBadge from './DifficultyBadge.vue'
 import { useBreakpoint } from '@/composables/useBreakpoint'
 import { sortByDifficulty } from '@/utils/difficulty'
+import { getSongRecords } from '@/api/record'
 
 const { t } = useI18n()
 const { isMobile } = useBreakpoint()
@@ -86,9 +91,40 @@ const { isMobile } = useBreakpoint()
 const show = defineModel<boolean>('show', { required: true })
 const props = defineProps<{
   song: Song | null
+  username?: string
 }>()
 
+const songRecords = ref<PlayRecordInfo[]>([])
+const loadingRecords = ref(false)
+
 const sortedCharts = computed(() => sortByDifficulty(props.song?.charts ?? []))
+
+const recordMap = computed(() => {
+  const map = new Map<number, PlayRecordInfo>()
+  for (const r of songRecords.value) {
+    if (r.chart.id) map.set(r.chart.id, r)
+  }
+  return map
+})
+
+const getRecord = (chartId: number) => recordMap.value.get(chartId) ?? null
+
+watch(() => props.song, async (song) => {
+  songRecords.value = []
+  if (!song || !props.username) {
+    return
+  }
+  loadingRecords.value = true
+  try {
+    const addr = String(song.id)
+    const res = await getSongRecords(props.username, addr, 'best')
+    songRecords.value = res.data.records
+  } catch {
+    songRecords.value = []
+  } finally {
+    loadingRecords.value = false
+  }
+})
 
 const modalStyle = computed(() =>
   (isMobile.value
@@ -179,6 +215,7 @@ const coverUrl = computed(() => {
   padding: var(--space-2) var(--space-3);
   background: var(--bg-secondary);
   border-radius: 6px;
+  flex-wrap: wrap;
 }
 .chart-designer {
   font-size: var(--text-sm);
@@ -188,6 +225,23 @@ const coverUrl = computed(() => {
 .chart-notes {
   font-size: var(--text-xs);
   color: var(--text-muted);
+}
+.chart-record {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}
+.record-rating {
+  color: var(--accent);
+  font-weight: 600;
+}
+@media (max-width: 479px) {
+  .chart-record {
+    width: 100%;
+    justify-content: flex-end;
+  }
 }
 .loading-state {
   display: flex;

--- a/web/src/components/business/SongGridView.vue
+++ b/web/src/components/business/SongGridView.vue
@@ -126,27 +126,13 @@ defineEmits<{
 
 .level-cards {
   display: flex;
+  flex-wrap: wrap;
   gap: var(--space-3);
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  scrollbar-width: thin;
-  scrollbar-color: var(--border) transparent;
-  padding-bottom: var(--space-1);
   flex: 1;
   min-width: 0;
 }
-.level-cards::-webkit-scrollbar {
-  height: 4px;
-}
-.level-cards::-webkit-scrollbar-track {
-  background: transparent;
-}
-.level-cards::-webkit-scrollbar-thumb {
-  background: var(--border);
-  border-radius: 2px;
-}
 
-/* Cards in level rows should have fixed width */
+/* Cards in level rows keep a fixed width and wrap to a new line. */
 .level-cards :deep(.song-grid-card) {
   flex-shrink: 0;
   width: 130px;

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -96,6 +96,7 @@ const en = {
     b50_global: 'Global B50',
     overflow: 'Overflow',
     my_score: 'My Score',
+    best_score: 'Best Score',
   },
   message: {
     welcome: 'Welcome, {username}!',

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -90,6 +90,12 @@ const en = {
     avg_rating: 'Avg Rating',
     total_rating: 'Total Rating',
     scope: 'Scope',
+    export_mode: 'Export Mode',
+    b50_standard: 'Standard B50',
+    b50_overflow: 'B50 + Overflow',
+    b50_global: 'Global B50',
+    overflow: 'Overflow',
+    my_score: 'My Score',
   },
   message: {
     welcome: 'Welcome, {username}!',

--- a/web/src/i18n/ja.ts
+++ b/web/src/i18n/ja.ts
@@ -88,6 +88,12 @@ const ja = {
     avg_rating: '平均レーティング',
     total_rating: '合計レーティング',
     scope: '範囲',
+    export_mode: 'エクスポートモード',
+    b50_standard: '標準 B50',
+    b50_overflow: 'B50 + オーバーフロー',
+    b50_global: 'グローバル B50',
+    overflow: 'オーバーフロー',
+    my_score: 'マイスコア',
   },
   message: {
     welcome: 'ようこそ、{username}！',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -96,6 +96,7 @@ const zh = {
     b50_global: '全局 B50',
     overflow: '下溢',
     my_score: '我的成绩',
+    best_score: '最佳成绩',
   },
   message: {
     welcome: '欢迎，{username}！',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -90,6 +90,12 @@ const zh = {
     avg_rating: '平均 Rating',
     total_rating: '总 Rating',
     scope: '范围',
+    export_mode: '导出模式',
+    b50_standard: '标准 B50',
+    b50_overflow: 'B50 + 下溢',
+    b50_global: '全局 B50',
+    overflow: '下溢',
+    my_score: '我的成绩',
   },
   message: {
     welcome: '欢迎，{username}！',

--- a/web/src/utils/b50Canvas.ts
+++ b/web/src/utils/b50Canvas.ts
@@ -11,6 +11,8 @@ export interface B50Section {
   label: string
   avg: number
   records: PlayRecordInfo[]
+  /** Records with index >= cutoff are rendered dimmed (overflow/floor). */
+  cutoff?: number
 }
 
 export interface B50RenderOptions {
@@ -315,6 +317,7 @@ function drawRecordCard(
   record: PlayRecordInfo,
   rank: number,
   coverImage: HTMLImageElement | null,
+  isOverflow = false,
 ) {
   // ── Card shadow (drawn before clip so it's visible outside) ──
   ctx.save()
@@ -412,6 +415,12 @@ function drawRecordCard(
   ctx.shadowOffsetX = 0
   ctx.shadowOffsetY = 0
 
+  // Dim overflow (floor) cards so the B50 boundary is visually obvious
+  if (isOverflow) {
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.38)'
+    ctx.fillRect(x, y, w, h)
+  }
+
   ctx.restore()
 }
 
@@ -430,6 +439,7 @@ function drawCardGrid(
   startY: number,
   records: PlayRecordInfo[],
   imageMap: Map<string, HTMLImageElement>,
+  cutoff?: number,
 ) {
   records.forEach((record, i) => {
     const col = i % COLS
@@ -437,7 +447,8 @@ function drawCardGrid(
     const cx = PADDING_X + col * (CARD_WIDTH + CARD_GAP)
     const cy = startY + row * (CARD_HEIGHT + CARD_GAP)
     const img = imageMap.get(record.chart.cover) ?? null
-    drawRecordCard(ctx, cx, cy, CARD_WIDTH, CARD_HEIGHT, record, i + 1, img)
+    const isOverflow = cutoff != null && i >= cutoff
+    drawRecordCard(ctx, cx, cy, CARD_WIDTH, CARD_HEIGHT, record, i + 1, img, isOverflow)
   })
 }
 
@@ -505,7 +516,7 @@ export async function renderB50Image(options: B50RenderOptions): Promise<Blob> {
     drawSectionTitle(ctx, titleY, section.label, section.avg)
     curY += SECTION_TITLE_HEIGHT + GAP_AFTER_SECTION_TITLE
 
-    drawCardGrid(ctx, curY, section.records, imageMap)
+    drawCardGrid(ctx, curY, section.records, imageMap, section.cutoff)
     curY += gridBlockHeight(section.records.length)
 
     if (i < sections.length - 1) {

--- a/web/src/utils/b50Canvas.ts
+++ b/web/src/utils/b50Canvas.ts
@@ -1,20 +1,24 @@
 /**
  * B50 image canvas renderer.
- * Generates a B50 best records image using Canvas 2D API.
+ * Generates a Best Records image using Canvas 2D API.
  */
 import type { PlayRecordInfo } from '@/api/types'
 import { coverUrl as coverFullUrl, coverThumbUrl } from '@/utils/cover'
 
 // ─── Render Options ────────────────────────────────────────────
 
+export interface B50Section {
+  label: string
+  avg: number
+  records: PlayRecordInfo[]
+}
+
 export interface B50RenderOptions {
-  b15Records: PlayRecordInfo[]
-  b35Records: PlayRecordInfo[]
+  sections: B50Section[]
   username: string
   nickname: string
-  rating: number   // Player overall rating (avg B50, already /100)
-  b15Avg: number   // B15 avg rating (already /100)
-  b35Avg: number   // B35 avg rating (already /100)
+  rating: number
+  title?: string
 }
 
 // ─── Layout Constants ──────────────────────────────────────────
@@ -250,7 +254,7 @@ function drawHeader(
   ctx.fillStyle = '#ffffff'
   ctx.textAlign = 'left'
   ctx.textBaseline = 'top'
-  ctx.fillText('Paradigm: Reboot Best Records', leftX, y)
+  ctx.fillText(options.title || 'Paradigm: Reboot Best Records', leftX, y)
 
   // Left: date/time
   ctx.font = `16px ${FONT_SANS}`
@@ -455,24 +459,23 @@ export async function renderB50Image(options: B50RenderOptions): Promise<Blob> {
     document.fonts.load(`16px ${FONT_MONO}`),
   ])
 
-  const { b15Records, b35Records } = options
+  const { sections } = options
 
   // ── Calculate total canvas height ──
-  const b15BlockH = gridBlockHeight(b15Records.length)
-  const b35BlockH = gridBlockHeight(b35Records.length)
+  let contentHeight = 0
+  for (let i = 0; i < sections.length; i++) {
+    const section = sections[i]
+    contentHeight += SECTION_TITLE_HEIGHT + GAP_AFTER_SECTION_TITLE + gridBlockHeight(section.records.length)
+    if (i < sections.length - 1) {
+      contentHeight += GAP_BETWEEN_SECTIONS
+    }
+  }
 
   const canvasHeight =
     PADDING_TOP +
     HEADER_HEIGHT +
     GAP_AFTER_HEADER +
-    SECTION_TITLE_HEIGHT +
-    GAP_AFTER_SECTION_TITLE +
-    b15BlockH +
-    GAP_BETWEEN_SECTIONS +
-    SECTION_TITLE_HEIGHT +
-    GAP_AFTER_SECTION_TITLE +
-    b35BlockH +
-    GAP_BETWEEN_SECTIONS +
+    contentHeight +
     FOOTER_HEIGHT +
     PADDING_BOTTOM
 
@@ -483,7 +486,7 @@ export async function renderB50Image(options: B50RenderOptions): Promise<Blob> {
   const ctx = canvas.getContext('2d')!
 
   // ── Preload cover images ──
-  const allRecords = [...b15Records, ...b35Records]
+  const allRecords = sections.flatMap((s) => s.records)
   const imageMap = await preloadImages(allRecords)
 
   // ── Background (fixed image) ──
@@ -495,21 +498,20 @@ export async function renderB50Image(options: B50RenderOptions): Promise<Blob> {
   drawHeader(ctx, curY, options)
   curY += HEADER_HEIGHT + GAP_AFTER_HEADER
 
-  // ── Best 15 section ──
-  const b15TitleY = curY + SECTION_TITLE_HEIGHT / 2
-  drawSectionTitle(ctx, b15TitleY, 'Best 15', options.b15Avg)
-  curY += SECTION_TITLE_HEIGHT + GAP_AFTER_SECTION_TITLE
+  // ── Sections ──
+  for (let i = 0; i < sections.length; i++) {
+    const section = sections[i]
+    const titleY = curY + SECTION_TITLE_HEIGHT / 2
+    drawSectionTitle(ctx, titleY, section.label, section.avg)
+    curY += SECTION_TITLE_HEIGHT + GAP_AFTER_SECTION_TITLE
 
-  drawCardGrid(ctx, curY, b15Records, imageMap)
-  curY += b15BlockH + GAP_BETWEEN_SECTIONS
+    drawCardGrid(ctx, curY, section.records, imageMap)
+    curY += gridBlockHeight(section.records.length)
 
-  // ── Best 35 section ──
-  const b35TitleY = curY + SECTION_TITLE_HEIGHT / 2
-  drawSectionTitle(ctx, b35TitleY, 'Best 35', options.b35Avg)
-  curY += SECTION_TITLE_HEIGHT + GAP_AFTER_SECTION_TITLE
-
-  drawCardGrid(ctx, curY, b35Records, imageMap)
-  curY += b35BlockH + GAP_BETWEEN_SECTIONS
+    if (i < sections.length - 1) {
+      curY += GAP_BETWEEN_SECTIONS
+    }
+  }
 
   // ── Footer ──
   drawFooter(ctx, curY)

--- a/web/src/views/Best50View.vue
+++ b/web/src/views/Best50View.vue
@@ -5,11 +5,10 @@
       <div class="page-actions">
         <IconButton
           :title="t('common.export_image')"
-          :disabled="exporting || allRecords.length === 0"
-          @click="exportImage"
+          :disabled="allRecords.length === 0"
+          @click="showExportModal = true"
         >
-          <ImageDown v-if="!exporting" :size="18" />
-          <Loader v-else class="spin" :size="18" />
+          <ImageDown :size="18" />
         </IconButton>
         <IconButton
           :icon="RefreshCw"
@@ -80,7 +79,7 @@
     </div>
   </div>
 
-  <SongDetailModal v-model:show="showSongDetail" :song="selectedSong" />
+  <SongDetailModal v-model:show="showSongDetail" :song="selectedSong" :username="userStore.username" />
   <QuickUploadModal
     v-model:show="showQuickUpload"
     :title="uploadTarget.title"
@@ -90,15 +89,24 @@
     :cover="uploadTarget.cover"
     @success="loadData"
   />
+  <B50ExportModal
+    v-model:show="showExportModal"
+    :username="USE_MOCK ? 'demo_user' : userStore.username"
+    :nickname="userStore.profile?.nickname || nickname"
+    :rating="b50Rating"
+    :b15-records="b15Records"
+    :b35-records="b35Records"
+    :b15-avg="b15Rating"
+    :b35-avg="b35Rating"
+  />
 </template>
 
 <script setup lang="ts">
 import { ref, computed, onMounted, watch, h } from 'vue'
-import { saveAs } from 'file-saver'
 import { useI18n } from 'vue-i18n'
 import { NDataTable } from 'naive-ui'
 import type { DataTableColumns } from 'naive-ui'
-import { ImageDown, Loader, RefreshCw, Plus, Upload } from '@lucide/vue';
+import { ImageDown, RefreshCw, Plus, Upload } from '@lucide/vue';
 import VChart from 'vue-echarts'
 import { use } from 'echarts/core'
 import { ScatterChart } from 'echarts/charts'
@@ -113,13 +121,13 @@ import { getRecords } from '@/api/record'
 import { getSingleSongInfo } from '@/api/song'
 import { USE_MOCK, getMockB50 } from '@/api/mock'
 import type { PlayRecordInfo, Song, Difficulty } from '@/api/types'
-import { renderB50Image } from '@/utils/b50Canvas'
 import BaseCard from '@/components/ui/BaseCard.vue'
 import IconButton from '@/components/ui/IconButton.vue'
 import StatCard from '@/components/business/StatCard.vue'
 import DifficultyBadge from '@/components/business/DifficultyBadge.vue'
 import SongDetailModal from '@/components/business/SongDetailModal.vue'
 import QuickUploadModal from '@/components/business/QuickUploadModal.vue'
+import B50ExportModal from '@/components/business/B50ExportModal.vue'
 import VersionAnnounceBanner from '@/components/business/VersionAnnounceBanner.vue'
 
 use([ScatterChart, GridComponent, TooltipComponent, CanvasRenderer])
@@ -132,8 +140,9 @@ const allRecords = ref<PlayRecordInfo[]>([])
 const nickname = ref('')
 const showSongDetail = ref(false)
 const selectedSong = ref<Song | null>(null)
-const exporting = ref(false)
+
 const showQuickUpload = ref(false)
+const showExportModal = ref(false)
 const uploadTarget = ref({ title: '', difficulty: 'detected' as Difficulty, level: 0, chartId: 0, cover: '' })
 
 const b35Records = computed(() =>
@@ -357,28 +366,6 @@ const refreshData = async () => {
   if (ok) toastSuccess('message.refresh_record_success')
 }
 
-const exportImage = async () => {
-  if (exporting.value || allRecords.value.length === 0) return
-  exporting.value = true
-  try {
-    const blob = await renderB50Image({
-      b15Records: b15Records.value,
-      b35Records: b35Records.value,
-      username: USE_MOCK ? 'demo_user' : userStore.username,
-      nickname: userStore.profile?.nickname || nickname.value,
-      rating: b50Rating.value,
-      b15Avg: b15Rating.value,
-      b35Avg: b35Rating.value,
-    })
-    saveAs(blob, `b50_${Date.now()}.jpg`)
-    toastSuccess('message.export_image_success')
-  } catch (err: unknown) {
-    toastError('message.export_image_failed', err)
-  } finally {
-    exporting.value = false
-  }
-}
-
 watch(() => userStore.logged_in, (loggedIn) => {
   if (loggedIn) loadData()
 })
@@ -458,11 +445,4 @@ onMounted(loadData)
   :deep(.action-btn:hover) { background: rgba(255,255,255,0.06); color: var(--text-primary); }
 }
 
-@keyframes spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
-}
-.spin {
-  animation: spin 1s linear infinite;
-}
 </style>

--- a/web/src/views/RecordsView.vue
+++ b/web/src/views/RecordsView.vue
@@ -79,7 +79,7 @@
   </div>
 
   <!-- Modals -->
-  <SongDetailModal v-model:show="showSongDetail" :song="selectedSong" />
+  <SongDetailModal v-model:show="showSongDetail" :song="selectedSong" :username="userStore.username" />
   <CsvImportModal v-model:show="showCsvImport" @success="loadRecords" />
   <QuickUploadModal
     v-model:show="showQuickUpload"

--- a/web/src/views/SongsView.vue
+++ b/web/src/views/SongsView.vue
@@ -107,7 +107,7 @@
   </div>
 
   <!-- Modals -->
-  <SongDetailModal v-model:show="showSongDetail" :song="selectedSong" />
+  <SongDetailModal v-model:show="showSongDetail" :song="selectedSong" :username="userStore.username" />
   <QuickUploadModal
     v-model:show="showQuickUpload"
     :title="uploadTarget.title"
@@ -126,6 +126,7 @@ import { Search, RefreshCw, LayoutGrid, List } from '@lucide/vue'
 
 import { toastSuccess, toastError } from '@/utils/toast'
 
+import { useUserStore } from '@/stores/user'
 import { useAppStore } from '@/stores/app'
 import { getAllCharts, getSingleSongInfo } from '@/api/song'
 import { USE_MOCK, getMockCharts } from '@/api/mock'
@@ -144,6 +145,7 @@ const SongGridView = defineAsyncComponent(() => import('@/components/business/So
 const SongTableView = defineAsyncComponent(() => import('@/components/business/SongTableView.vue'))
 
 const { t } = useI18n()
+const userStore = useUserStore()
 const appStore = useAppStore()
 
 // --- Composables ---


### PR DESCRIPTION
  - Add B50ExportModal with three export modes: 
  - Standard B50 (existing b15+b35), B50 + Overflow (fetch underflow=5 via /records/{username}?scope=b50&underflow=5), Global B50 (fetch scope=all&page_size=50 via /records/{username}?scope=all)
  - Refactor b50Canvas.ts from fixed b15/b35 structure to dynamic B50Section[] arrays so canvas height and section titles adjust automatically
  - Update Best50View.vue to open export modal instead of direct download
  - Enhance SongDetailModal.vue: Fetch player best records per song via GET /records/{username}/song/{song_addr}; Display score and rating next to each difficulty chart;  Fix mobile layout: add flex-wrap to chart-row so elements wrap on narrow screens
  - Extend record API wrappers: Add underflow param to getRecords(), Add getSongRecords() for song-scoped queries
  - Add i18n keys for export modes and overflow across en/zh/ja