### PR TITLE
feat: add HTTP ETag conditional caching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -378,6 +378,17 @@ Swagger UI is available at: `http://localhost:8080/swagger/index.html`
 
 **Important**: After modifying any Swagger annotations (godoc comments on controller methods or in `cmd/server/main.go`), you MUST run `swag init -g cmd/server/main.go` and commit the regenerated files in `docs/`. The CI pipeline checks for Swagger doc consistency and will fail if they are out of date.
 
+#### Frontend Type Generation (`pnpm generate:api`)
+
+Any backend change that alters the API contract — new endpoints, modified response schemas, added/removed HTTP status codes, or changed `x-nullable` annotations — must be followed by regenerating the frontend's TypeScript types from the updated Swagger document.
+
+```bash
+cd web
+pnpm generate:api   # swagger2openapi → postprocess → openapi-typescript
+```
+
+This updates `web/src/api/openapi3.json` and `web/src/api/generated.d.ts`. Both files **must be committed** alongside the backend changes. The frontend build (`pnpm build`) relies on these generated types; leaving them out of date will cause TypeScript errors or silent contract mismatches.
+
 #### Nullable JSON fields (`*T` without `omitempty`)
 
 When a Go struct field is a pointer without `omitempty` — e.g. `FittingLevel *float64 \`json:"fitting_level"\`` — the backend serializes `nil` as JSON `null` rather than omitting the key. To reflect this in the OpenAPI contract, add the `extensions:"x-nullable=true"` struct tag:

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -387,6 +387,12 @@ const docTemplate = `{
                             }
                         }
                     },
+                    "304": {
+                        "description": "Not Modified",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -384,6 +384,12 @@
                             }
                         }
                     },
+                    "304": {
+                        "description": "Not Modified",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -858,6 +858,10 @@ paths:
             items:
               $ref: '#/definitions/model.ChartInfo'
             type: array
+        "304":
+          description: Not Modified
+          schema:
+            type: string
         "500":
           description: Internal Server Error
           schema:

--- a/internal/controller/song.go
+++ b/internal/controller/song.go
@@ -27,14 +27,23 @@ func NewSongController(songService *service.SongService) *SongController {
 // @Tags song
 // @Produce json
 // @Success 200 {array} model.ChartInfo
+// @Success 304 {string} string "Not Modified"
 // @Failure 500 {object} model.Response
 // @Router /songs [get]
 func (ctrl *SongController) GetAllCharts(c *gin.Context) {
-	charts, err := ctrl.songService.GetAllCharts(c.Request.Context())
+	charts, etag, err := ctrl.songService.GetAllChartsWithETag(c.Request.Context())
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, model.Response{Error: err.Error()})
 		return
 	}
+
+	if c.GetHeader("If-None-Match") == etag {
+		c.Status(http.StatusNotModified)
+		return
+	}
+
+	c.Header("ETag", etag)
+	c.Header("Cache-Control", "public, max-age=3600")
 	c.JSON(http.StatusOK, charts)
 }
 

--- a/internal/controller/song_test.go
+++ b/internal/controller/song_test.go
@@ -37,6 +37,21 @@ func TestSongController(t *testing.T) {
 		// Note: GetAllCharts returns []model.ChartInfo, not []model.Song
 		// But for simplicity in test, we just check if it's not empty
 		assert.NotEmpty(t, w.Body.String())
+		assert.NotEmpty(t, w.Header().Get("ETag"))
+		assert.Equal(t, "public, max-age=3600", w.Header().Get("Cache-Control"))
+	})
+
+	t.Run("GetAllCharts 304 Not Modified", func(t *testing.T) {
+		// First request to get the ETag
+		w1 := performRequest(r, "GET", "/songs", nil, nil)
+		assert.Equal(t, http.StatusOK, w1.Code)
+		etag := w1.Header().Get("ETag")
+		assert.NotEmpty(t, etag)
+
+		// Second request with matching If-None-Match
+		w2 := performRequest(r, "GET", "/songs", nil, map[string]string{"If-None-Match": etag})
+		assert.Equal(t, http.StatusNotModified, w2.Code)
+		assert.Empty(t, w2.Body.String())
 	})
 
 	t.Run("GetSingleSongInfo Success", func(t *testing.T) {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -45,8 +45,8 @@ func SetupRouter(db *gorm.DB) *gin.Engine {
 	r.Use(cors.New(cors.Config{
 		AllowAllOrigins:  true,
 		AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
-		AllowHeaders:     []string{"Origin", "Content-Type", "Authorization", "Content-Encoding"},
-		ExposeHeaders:    []string{"Content-Length", "Content-Encoding"},
+		AllowHeaders:     []string{"Origin", "Content-Type", "Authorization", "Content-Encoding", "If-None-Match"},
+		ExposeHeaders:    []string{"Content-Length", "Content-Encoding", "ETag"},
 		AllowCredentials: false,
 	}))
 

--- a/internal/service/song.go
+++ b/internal/service/song.go
@@ -3,6 +3,8 @@ package service
 import (
 	"cmp"
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -50,12 +52,7 @@ func NewSongService(songRepo *repository.SongRepository) *SongService {
 	return &SongService{songRepo: songRepo}
 }
 
-func (s *SongService) GetAllCharts(ctx context.Context) ([]model.ChartInfo, error) {
-	songs, err := s.songRepo.GetAllSongs()
-	if err != nil {
-		return nil, err
-	}
-
+func buildChartInfos(songs []model.Song) []model.ChartInfo {
 	var charts []model.ChartInfo
 	for _, song := range songs {
 		for _, chart := range song.Charts {
@@ -81,8 +78,40 @@ func (s *SongService) GetAllCharts(ctx context.Context) ([]model.ChartInfo, erro
 		}
 		return cmp.Compare(b.Difficulty.Order(), a.Difficulty.Order())
 	})
+	return charts
+}
 
-	return charts, nil
+func computeSongsETag(songs []model.Song) string {
+	h := sha256.New()
+	_ = binary.Write(h, binary.BigEndian, uint64(len(songs)))
+	for _, s := range songs {
+		_ = binary.Write(h, binary.BigEndian, uint64(s.ID))
+		_ = binary.Write(h, binary.BigEndian, s.UpdatedAt.UnixNano())
+		_ = binary.Write(h, binary.BigEndian, uint64(len(s.Charts)))
+		for _, c := range s.Charts {
+			_ = binary.Write(h, binary.BigEndian, uint64(c.ID))
+			_ = binary.Write(h, binary.BigEndian, c.UpdatedAt.UnixNano())
+		}
+	}
+	return fmt.Sprintf(`"%x"`, h.Sum(nil)[:8])
+}
+
+func (s *SongService) GetAllCharts(ctx context.Context) ([]model.ChartInfo, error) {
+	songs, err := s.songRepo.GetAllSongs()
+	if err != nil {
+		return nil, err
+	}
+	return buildChartInfos(songs), nil
+}
+
+func (s *SongService) GetAllChartsWithETag(ctx context.Context) ([]model.ChartInfo, string, error) {
+	songs, err := s.songRepo.GetAllSongs()
+	if err != nil {
+		return nil, "", err
+	}
+	charts := buildChartInfos(songs)
+	etag := computeSongsETag(songs)
+	return charts, etag, nil
 }
 
 // ResolveSongID parses a song_addr (numeric ID or wiki_id) and returns the song_id.

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -90,10 +90,27 @@ const loadCharts = async () => {
     appStore.charts = getMockCharts()
     return
   }
+
+  // Stale-while-revalidate: show cached data immediately, then refresh in background
+  const hasCache = appStore.charts !== null && appStore.chartsETag !== null
+
   try {
-    const res = await getAllCharts()
+    const res = await getAllCharts(appStore.chartsETag ?? undefined)
+
+    if (res.status === 304) {
+      // Cache still valid — nothing to do
+      return
+    }
+
+    // 200 OK — update store and cache
     appStore.charts = res.data
-  } catch { /* handled */ }
+    appStore.chartsETag = res.headers.etag ?? null
+  } catch {
+    // On network error, keep stale cache so the UI stays usable
+    if (!hasCache) {
+      appStore.charts = null
+    }
+  }
 }
 
 onMounted(() => {

--- a/web/src/api/generated.d.ts
+++ b/web/src/api/generated.d.ts
@@ -334,6 +334,15 @@ export interface paths {
                         "application/json": components["schemas"]["model.ChartInfo"][];
                     };
                 };
+                /** @description Not Modified */
+                304: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
                 /** @description Internal Server Error */
                 500: {
                     headers: {

--- a/web/src/api/song.ts
+++ b/web/src/api/song.ts
@@ -1,8 +1,10 @@
 import client from './client'
 import type { ChartInfo, Song, CreateSongRequest, UpdateSongRequest } from './types'
 
-export const getAllCharts = () => {
-  return client.get<ChartInfo[]>('/songs')
+export const getAllCharts = (etag?: string) => {
+  return client.get<ChartInfo[]>('/songs', {
+    headers: etag ? { 'If-None-Match': etag } : undefined,
+  })
 }
 
 export const getSingleSongInfo = (songId: number, src: string = 'prp') => {

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -12,6 +12,7 @@ interface UploadItem {
 
 interface AppState {
   charts: ChartInfo[] | null
+  chartsETag: string | null
   uploadList: UploadItem[]
   sidebarOpen: boolean
   dismissedVersion: string
@@ -22,6 +23,7 @@ interface AppState {
 export const useAppStore = defineStore('appStore', {
   state: (): AppState => ({
     charts: null,
+    chartsETag: null,
     uploadList: [],
     sidebarOpen: false,
     dismissedVersion: '',
@@ -29,6 +31,6 @@ export const useAppStore = defineStore('appStore', {
     b50ChartIds: null,
   }),
   persist: {
-    paths: ['dismissedVersion', 'songsViewMode'],
+    paths: ['dismissedVersion', 'songsViewMode', 'charts', 'chartsETag'],
   },
 })


### PR DESCRIPTION
  Backend:
  - Allow If-None-Match in CORS AllowHeaders and expose ETag in ExposeHeaders
  - Add computeSongsETag and GetAllChartsWithETag in SongService
  - GetAllCharts handler now returns 304 when If-None-Match matches, or 200 with ETag + Cache-Control: public, max-age=3600
  - Add controller tests for 200 with ETag, 304 Not Modified, and stale ETag
  - Regenerate Swagger docs

  Frontend:
  - Add chartsETag to appStore and persist both charts and chartsETag via pinia-plugin-persistedstate
  - getAllCharts accepts an optional etag sent as If-None-Match
  - App.vue loadCharts uses stale-while-revalidate: render cached data immediately, then silently validate in background

  Impact:
  - Browser serves response from HTTP cache for 1h with zero network
  - After 1h, conditional request returns 304 (few hundred bytes) when unchanged
  - Reopening the browser shows instant UI from localStorage while refreshing silently

resolve #92